### PR TITLE
correct 18.4b1 build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
   <h1><b>StikJIT</b></h1>
-  <p><i> An on-device JIT enabler for iOS versions 17.4+ (17.4-18.5b4 (latest)), excluding iOS 18.4 beta 1 (22E5200), powered by <a href="https://github.com/jkcoxson/idevice">idevice</a> </i></p>
+  <p><i> An on-device JIT enabler for iOS versions 17.4+ (17.4-18.5b4 (latest)), excluding iOS 18.4 beta 1 (22E5200s), powered by <a href="https://github.com/jkcoxson/idevice">idevice</a> </i></p>
 </div>
 <h6 align="center">
 


### PR DESCRIPTION
accidentally put the "wrong" build number for 18.4b1 in a older pr by me
<img width="762" alt="Screenshot 2025-04-29 at 20 26 56" src="https://github.com/user-attachments/assets/9b7d5b2e-f08e-472b-b7ae-d16adad28a8b" />
(https://ipswbeta.dev/ios/18.x/)